### PR TITLE
feat: タイトルシーンの実装

### DIFF
--- a/src/looper/looper.cpp
+++ b/src/looper/looper.cpp
@@ -88,18 +88,19 @@ bool looper_init(Looper *looper, eSceneType default_scene)
         return false;
     }
 
+    // Joycon初期化
+    if (!joycon_init(&looper->joycon)) return false;
+
     // SceneManager初期化
     looper->scene_manager = make_unique<SceneManager>();
     looper->scene_manager->context = &g_context;
+    looper->scene_manager->joycon = &looper->joycon;
     if (!scene_manager_init(looper->scene_manager, default_scene))
     {
         LOG_ERROR("シーンの初期化に失敗しました");
         return false;
     }
 
-    // if (!joycon_init(&looper->joycon)) return false;
-
-    joycon_init(&looper->joycon);
     return true;
 }
 

--- a/src/scene/title/title_scene.cpp
+++ b/src/scene/title/title_scene.cpp
@@ -1,0 +1,73 @@
+#include "title_scene.hpp"
+
+#include "glad/glad.h"
+#include "util/log.hpp"
+
+bool title_scene_init(TitleScene *scene)
+{
+    scene->font = EZ_2D_CreateFont("fonts/font.otf", 48);
+    if (!scene->font)
+    {
+        LOG_ERROR("タイトルシーン: フォントの読み込みに失敗しました");
+        return false;
+    }
+
+    scene->blink_counter = 0;
+    scene->show_start_message = true;
+
+    LOG_DEBUG("タイトルシーンを初期化しました");
+    return true;
+}
+
+bool title_scene_update(TitleScene *scene)
+{
+    // 点滅アニメーション更新
+    scene->blink_counter++;
+    if (scene->blink_counter >= BLINK_INTERVAL)
+    {
+        scene->blink_counter = 0;
+        scene->show_start_message = !scene->show_start_message;
+    }
+
+    // Aボタンが押されたらシーン遷移
+    if (scene->joycon != nullptr && scene->joycon->joycon.button.btn.A)
+    {
+        LOG_DEBUG("タイトルシーン: Aボタン入力を検出、ゲームシーンに遷移します");
+        return true;
+    }
+
+    return false;
+}
+
+void title_scene_draw(TitleScene *scene)
+{
+    // 背景を黒でクリア
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    float screen_width = static_cast<float>(scene->context->window_width);
+    float screen_height = static_cast<float>(scene->context->window_height);
+
+    // タイトルテキストを中央に描画
+    const char *title_text = "超次元テニス";
+    float title_x = screen_width / 2.0f - 300.0f;
+    float title_y = screen_height * 0.3f;
+    EZ_2D_DrawText(scene->font, title_x, title_y, title_text, TITLE_FONT_SIZE, 1.0f, 1.0f, 1.0f,
+                   1.0f);
+
+    // 開始メッセージ（点滅）
+    if (scene->show_start_message)
+    {
+        const char *start_text = "Press A";
+        float start_x = screen_width / 2.0f - 200.0f;
+        float start_y = screen_height * 0.6f;
+        EZ_2D_DrawText(scene->font, start_x, start_y, start_text, START_MSG_FONT_SIZE, 0.8f, 0.8f,
+                       0.8f, 1.0f);
+    }
+}
+
+void title_scene_fini(TitleScene *scene)
+{
+    scene->font.reset();
+    LOG_DEBUG("タイトルシーンを終了しました");
+}

--- a/src/scene/title/title_scene.hpp
+++ b/src/scene/title/title_scene.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "core/context.hpp"
+#include "joycon/joycon.hpp"
+#include "opengl/2d/EZ_2d.h"
+
+// タイトル表示設定
+constexpr float TITLE_FONT_SIZE = 72.0f;
+constexpr float START_MSG_FONT_SIZE = 32.0f;
+
+// 点滅間隔（フレーム数）
+constexpr int BLINK_INTERVAL = 30;
+
+struct TitleScene
+{
+    Context *context;
+    Joycon *joycon;
+    EZ_2D_Font font;
+    int blink_counter;
+    bool show_start_message;
+};
+
+/// @brief タイトルシーンの初期化
+bool title_scene_init(TitleScene *scene);
+
+/// @brief タイトルシーンの更新
+/// @return trueならゲームシーンに遷移する
+bool title_scene_update(TitleScene *scene);
+
+/// @brief タイトルシーンの描画
+void title_scene_draw(TitleScene *scene);
+
+/// @brief タイトルシーンの終了処理
+void title_scene_fini(TitleScene *scene);

--- a/src/scene_manager/scene_manager.cpp
+++ b/src/scene_manager/scene_manager.cpp
@@ -19,7 +19,9 @@ static bool init_scene(unique_ptr<SceneManager> &mgr)
     {
         case SCENE_TITLE:
             LOG_DEBUG("SCENE_TITLEを初期化します。");
-            return true;
+            mgr->title_scene.context = mgr->context;
+            mgr->title_scene.joycon = mgr->joycon;
+            return title_scene_init(&mgr->title_scene);
 
         case SCENE_GAME:
             LOG_DEBUG("SCENE_GAMEを初期化します。");
@@ -41,11 +43,15 @@ bool scene_update(unique_ptr<SceneManager> &mgr, PlayerInput *player_input,
     switch (mgr->current_scene)
     {
         case SCENE_TITLE:
-            if (!scene_change(mgr, SCENE_GAME))
+        {
+            bool should_change = title_scene_update(&mgr->title_scene);
+            title_scene_draw(&mgr->title_scene);
+            if (should_change)
             {
-                return false;
+                return scene_change(mgr, SCENE_GAME);
             }
             return true;
+        }
 
         case SCENE_GAME:
             if (!game_scene_update(&mgr->game_scene, player_input, player_swing))
@@ -69,6 +75,7 @@ static void fini_scene(unique_ptr<SceneManager> &mgr)
     {
         case SCENE_TITLE:
             LOG_DEBUG("SCENE_TITLEを終了します。");
+            title_scene_fini(&mgr->title_scene);
             break;
         case SCENE_GAME:
             LOG_DEBUG("SCENE_GAMEを終了します。");

--- a/src/scene_manager/scene_manager.hpp
+++ b/src/scene_manager/scene_manager.hpp
@@ -7,7 +7,9 @@
 #include "common/player_input.h"
 #include "common/player_swing.h"
 #include "core/context.hpp"
+#include "joycon/joycon.hpp"
 #include "scene/game/game_scene.hpp"
+#include "scene/title/title_scene.hpp"
 #include "scene_type.hpp"
 
 using namespace std;
@@ -16,6 +18,8 @@ struct SceneManager
 {
     eSceneType current_scene;
     Context *context;
+    Joycon *joycon;
+    TitleScene title_scene;
     GameScene game_scene;
     PlayerInput player_input;
 };


### PR DESCRIPTION
## 🔗 Issue
closed #82 

## 📚 Description
タイトルシーンを実装しました。

- タイトル画面の表示（「超次元テニス」）
- 「Press A」メッセージの点滅アニメーション
- Joy-ConのAボタンでゲームシーンに遷移
- 画面サイズをContextから動的に取得

## 📸 Screenshot / 動作確認結果（必要があれば）
N/A

## 🚧 Not included in this PR
- タイトル画面のBGM
- タイトル画面の背景画像

## 📝 Reviewer checklist & Notes
- SceneManagerにJoyconポインタを追加し、タイトルシーンからボタン入力を取得できるようにしました
- 初期化順序を調整し、scene_manager_init前にjoycon_initを実行するようにしています