### PR TITLE
feat: Joyconボタン入力APIの追加

### DIFF
--- a/src/joycon/joycon.cpp
+++ b/src/joycon/joycon.cpp
@@ -34,6 +34,10 @@ bool joycon_init(Joycon *joycon)
     // スイング時刻を初期化
     joycon->last_swing_time_ms = 0;
 
+    // ボタン状態を初期化
+    memset(joycon->buttons, 0, sizeof(joycon->buttons));
+    memset(joycon->prev_buttons, 0, sizeof(joycon->prev_buttons));
+
     LOG_SUCCESS("Joy-Conの初期化に成功しました");
 
     return true;
@@ -152,6 +156,65 @@ bool joycon_has_significant_swing(Joycon *joycon, const PlayerSwing *current)
     }
 
     return false;
+}
+
+void joycon_update_buttons(Joycon *joycon)
+{
+    // 前フレームの状態を保存
+    memcpy(joycon->prev_buttons, joycon->buttons, sizeof(joycon->buttons));
+
+    // 現在の状態を取得（joycon_get_stateは既に呼ばれている前提）
+    const joycon_btn &btn = joycon->joycon.button;
+
+    // joyconlib_tのbtnフィールドから配列へマッピング
+    joycon->buttons[JOYCON_BTN_A] = btn.btn.A;
+    joycon->buttons[JOYCON_BTN_B] = btn.btn.B;
+    joycon->buttons[JOYCON_BTN_X] = btn.btn.X;
+    joycon->buttons[JOYCON_BTN_Y] = btn.btn.Y;
+    joycon->buttons[JOYCON_BTN_R] = btn.btn.R;
+    joycon->buttons[JOYCON_BTN_ZR] = btn.btn.ZR;
+    joycon->buttons[JOYCON_BTN_L] = btn.btn.L;
+    joycon->buttons[JOYCON_BTN_ZL] = btn.btn.ZL;
+    joycon->buttons[JOYCON_BTN_PLUS] = btn.btn.Plus;
+    joycon->buttons[JOYCON_BTN_MINUS] = btn.btn.Minus;
+    joycon->buttons[JOYCON_BTN_RSTICK] = btn.btn.RStick;
+    joycon->buttons[JOYCON_BTN_LSTICK] = btn.btn.LStick;
+    joycon->buttons[JOYCON_BTN_UP] = btn.btn.Up;
+    joycon->buttons[JOYCON_BTN_DOWN] = btn.btn.Down;
+    joycon->buttons[JOYCON_BTN_LEFT] = btn.btn.Left;
+    joycon->buttons[JOYCON_BTN_RIGHT] = btn.btn.Right;
+    joycon->buttons[JOYCON_BTN_HOME] = btn.btn.Home;
+    joycon->buttons[JOYCON_BTN_CAPTURE] = btn.btn.Capture;
+    // SR/SLは左右どちらかがあれば有効
+    joycon->buttons[JOYCON_BTN_SR] = btn.btn.SR_r || btn.btn.SR_l;
+    joycon->buttons[JOYCON_BTN_SL] = btn.btn.SL_r || btn.btn.SL_l;
+}
+
+bool joycon_is_pressed(const Joycon *joycon, JoyconButton button)
+{
+    if (button < 0 || button >= JOYCON_BTN_COUNT)
+    {
+        return false;
+    }
+    return joycon->buttons[button];
+}
+
+bool joycon_is_just_pressed(const Joycon *joycon, JoyconButton button)
+{
+    if (button < 0 || button >= JOYCON_BTN_COUNT)
+    {
+        return false;
+    }
+    return joycon->buttons[button] && !joycon->prev_buttons[button];
+}
+
+bool joycon_is_just_released(const Joycon *joycon, JoyconButton button)
+{
+    if (button < 0 || button >= JOYCON_BTN_COUNT)
+    {
+        return false;
+    }
+    return !joycon->buttons[button] && joycon->prev_buttons[button];
 }
 
 void joycon_fini(Joycon *joycon)

--- a/src/joycon/joycon.hpp
+++ b/src/joycon/joycon.hpp
@@ -6,12 +6,42 @@
 #include "common/player_input.h"
 #include "common/player_swing.h"
 
+// Joyconボタン定数
+enum JoyconButton
+{
+    JOYCON_BTN_A = 0,
+    JOYCON_BTN_B,
+    JOYCON_BTN_X,
+    JOYCON_BTN_Y,
+    JOYCON_BTN_R,
+    JOYCON_BTN_ZR,
+    JOYCON_BTN_L,
+    JOYCON_BTN_ZL,
+    JOYCON_BTN_PLUS,
+    JOYCON_BTN_MINUS,
+    JOYCON_BTN_RSTICK,
+    JOYCON_BTN_LSTICK,
+    JOYCON_BTN_UP,
+    JOYCON_BTN_DOWN,
+    JOYCON_BTN_LEFT,
+    JOYCON_BTN_RIGHT,
+    JOYCON_BTN_HOME,
+    JOYCON_BTN_CAPTURE,
+    JOYCON_BTN_SR,
+    JOYCON_BTN_SL,
+    JOYCON_BTN_COUNT  // ボタン数
+};
+
 struct Joycon
 {
     joyconlib_t joycon;
     PlayerInput cached_input;   // 前回の入力をキャッシュ
     PlayerSwing cached_swing;   // 前回のスイングをキャッシュ
     Uint32 last_swing_time_ms;  // 最後にswingを送信した時刻（ミリ秒）
+
+    // ボタン状態
+    bool buttons[JOYCON_BTN_COUNT];       // 現在のボタン状態
+    bool prev_buttons[JOYCON_BTN_COUNT];  // 前フレームのボタン状態
 };
 
 bool joycon_init(Joycon *joycon);
@@ -26,5 +56,17 @@ PlayerSwing get_joycon_swing(Joycon *joycon, int player_id);
 
 // スイング動作が閾値を超えたかチェック
 bool joycon_has_significant_swing(Joycon *joycon, const PlayerSwing *current);
+
+// ボタン状態を更新（毎フレーム呼ぶ）
+void joycon_update_buttons(Joycon *joycon);
+
+// ボタンが押されているか
+bool joycon_is_pressed(const Joycon *joycon, JoyconButton button);
+
+// ボタンが今押された瞬間か（エッジ検出）
+bool joycon_is_just_pressed(const Joycon *joycon, JoyconButton button);
+
+// ボタンが今離された瞬間か（エッジ検出）
+bool joycon_is_just_released(const Joycon *joycon, JoyconButton button);
 
 void joycon_fini(Joycon *joycon);

--- a/src/looper/looper.cpp
+++ b/src/looper/looper.cpp
@@ -114,6 +114,9 @@ void loop(Looper *looper)
 
         PlayerInput player_input = get_joycon(&looper->joycon, g_context.player_id);
 
+        // ボタン状態を更新
+        joycon_update_buttons(&looper->joycon);
+
         // 移動入力があるかチェック（どれか一つでもtrueなら入力あり）
         bool has_movement_input =
             player_input.left || player_input.right || player_input.front || player_input.back;

--- a/src/scene/title/title_scene.cpp
+++ b/src/scene/title/title_scene.cpp
@@ -29,8 +29,8 @@ bool title_scene_update(TitleScene *scene)
         scene->show_start_message = !scene->show_start_message;
     }
 
-    // Aボタンが押されたらシーン遷移
-    if (scene->joycon != nullptr && scene->joycon->joycon.button.btn.A)
+    // Aボタンが押された瞬間にシーン遷移
+    if (scene->joycon != nullptr && joycon_is_just_pressed(scene->joycon, JOYCON_BTN_A))
     {
         LOG_DEBUG("タイトルシーン: Aボタン入力を検出、ゲームシーンに遷移します");
         return true;


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## 🔗 Issue
N/A

## 📚 Description
Joyconのボタン入力を簡単に扱えるAPIを追加。

### 追加内容
- `JoyconButton` enum（A/B/X/Y/R/ZR等20種類のボタン定義）
- `joycon_update_buttons()` - 毎フレームのボタン状態更新
- `joycon_is_pressed()` - ボタン押下中判定
- `joycon_is_just_pressed()` - 押された瞬間のエッジ検出
- `joycon_is_just_released()` - 離された瞬間のエッジ検出

### 変更点
- title_sceneのAボタン判定を新APIに移行（押しっぱなし誤検知を防止）

## 📸 Screenshot / 動作確認結果（必要があれば）
N/A（ビルド確認は別環境で実施予定）

## 🚧 Not included in this PR
- 他のシーンでのボタン入力対応

## 📝 Reviewer checklist & Notes
- `joyconlib_t.button.btn`のビットフィールドから`bool`配列へのマッピングを実装
- SR/SLボタンは左右Joy-Conどちらかが押されていれば有効として処理